### PR TITLE
upload files in segments no larger than 5G

### DIFF
--- a/swiftrotate.sh
+++ b/swiftrotate.sh
@@ -39,7 +39,7 @@ else
     --os-region-name=$REGION \
     --os-service-type=object-store \
     --os-endpoint-type=internalURL \
-    upload -c $CONTAINER *.gz
+    upload -S 5368709120 -c $CONTAINER *.gz
     logger -t swiftrotate -p daemon.info "DONE uploading to Swift."
     rm $PIDFILE
 fi


### PR DESCRIPTION
For the upload to work with Rackspace Cloud Files, we need to specify --segment-size or -S, otherwise, uploads greater than 5G in size will fail with this error: Object PUT failed: 413 Request Entity Too Large.
